### PR TITLE
Update ingress.yml

### DIFF
--- a/kubernetes/ingress.yml
+++ b/kubernetes/ingress.yml
@@ -4,8 +4,8 @@ metadata:
   name: uber-like-app-ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/use-http2: "true"  # Optional: Enable HTTP/2 support
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"  # Specify protocol if necessary
+    nginx.ingress.kubernetes.io/use-http2: "true"  
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP" 
 spec:
   rules:
   - host: your-app-domain.com
@@ -15,13 +15,13 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: uber-like-app-frontend  # Match the Rollout service name
+            name: frontend-service 
             port:
               number: 80
       - path: /api
         pathType: Prefix
         backend:
           service:
-            name: uber-like-app-backend  # Match the Rollout service name
+            name: backend-service  
             port:
               number: 8080


### PR DESCRIPTION
Frontend Traffic Routing: Instead of directly linking to uber-like-app-frontend, the Ingress now routes traffic through frontend-service. This Service will dynamically switch its selector between blue and green deployments.Initially, the frontend-service selector will point to the blue version (app: frontend, version: blue).
When you're ready to switch to the green version, you’ll update the frontend-service selector to point to app: frontend, version: green.solve issue #7

### All Submissions:

- [ ] Have you followed the guidelines stated in [README.md](https://github.com/visheshrwl/Uber-like/tree
/main#how-to-contribute) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/visheshrwl/Uber-like/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #7 in your comment to auto-close the issue that your PR fixes (if such).